### PR TITLE
13673 maya 2025

### DIFF
--- a/hooks/core/bootstrap.py
+++ b/hooks/core/bootstrap.py
@@ -1,9 +1,5 @@
-# Copyright 2020 GPL Solutions, LLC.  All rights reserved.
-#
-# Use of this software is subject to the terms of the GPL Solutions license
-# agreement provided at the time of installation or download, or which otherwise
-# accompanies this software in either electronic or hard copy form.
-#
+# This file is provided by Epic Games, Inc. and is subject to the license
+# file included in this repository.
 
 """
 This hook is used override some of the functionality of the :class:`~sgtk.bootstrap.ToolkitManager`.
@@ -34,8 +30,8 @@ class Bootstrap(get_hook_baseclass()):
     Override the bootstrap core hook to cache ourself some bundles.
     http://developer.shotgunsoftware.com/tk-core/core.html#bootstrap.Bootstrap
     """
-    # List of github repos for which we download releases, with a token to do
-    # the download
+    # List of github repos for which we download releases, with a github token to
+    # do the download if the repo is private
     _download_release_from_github = [
         ("ue4plugins/tk-framework-unrealqt", ""),
         ("GPLgithub/tk-framework-unrealqt", ""),

--- a/hooks/tk-multi-publish2/tk-maya/basic/publish_fbx.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/publish_fbx.py
@@ -7,7 +7,6 @@ import maya.cmds as cmds
 import maya.mel as mel
 import sgtk
 from sgtk.util.filesystem import ensure_folder_exists
-from tank_vendor import six
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -363,13 +362,9 @@ class MayaFBXPublishPlugin(HookBaseClass):
 def _session_path():
     """
     Return the path to the current session
-    :return:
+    :return: A string or ``None``.
     """
     path = cmds.file(query=True, sn=True)
-
-    if path is not None:
-        path = six.ensure_str(path)
-
     return path
 
 

--- a/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
@@ -19,7 +19,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from six.moves.urllib import parse
+from urllib import parse
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -40,9 +40,19 @@ class BrowsablePathWidget(QtGui.QFrame):
         self.combo_box.setEditable(True)
         self.combo_box.setMaxVisibleItems(10)
         # Prevent the QComboBox to get too big if the path is long.
-        self.combo_box.setSizeAdjustPolicy(
-            QtGui.QComboBox.AdjustToMinimumContentsLength
-        )
+        engine = sgtk.platform.current_engine()
+        # Note: it would be better to test for Qt4 or Qt5 so this
+        # wouldn't have to be changed when moving to new major
+        # releases of Qt, but has_qt4 and has_qt5 returns True
+        # even when PySide6 is being used.
+        if engine.has_qt6:
+            self.combo_box.setSizeAdjustPolicy(
+                QtGui.QComboBox.AdjustToMinimumContentsLengthWithIcon
+            )
+        else:  # Qt4 or Qt5
+            self.combo_box.setSizeAdjustPolicy(
+                QtGui.QComboBox.AdjustToMinimumContentsLength
+            )
 
         self.open_button = QtGui.QToolButton()
         icon = QtGui.QIcon()
@@ -92,7 +102,7 @@ class BrowsablePathWidget(QtGui.QFrame):
 
         :returns: An utf-8 encoded string.
         """
-        return six.ensure_str(self.combo_box.currentText())
+        return self.combo_box.currentText()
 
     def set_path(self, path):
         """
@@ -540,14 +550,14 @@ class MayaUnrealTurntablePublishPlugin(HookBaseClass):
         # Please note that we don't have to return all settings here, just the
         # settings which are editable in the UI.
         settings = {
-            "Unreal Engine Version": six.ensure_str(widget.unreal_setup_widget.unreal_version),
-            "Unreal Engine Path": six.ensure_str(widget.unreal_setup_widget.unreal_path),
+            "Unreal Engine Version": widget.unreal_setup_widget.unreal_version,
+            "Unreal Engine Path": widget.unreal_setup_widget.unreal_path,
             # Get the project path evaluated from the template or the value which
             # was manually set.
-            "Unreal Project Path": six.ensure_str(widget.unreal_setup_widget.unreal_project_path),
-            "Turntable Map Path": six.ensure_str(widget.unreal_turntable_map_widget.text()),
-            "Sequence Path": six.ensure_str(widget.unreal_sequence_widget.text()),
-            "Turntable Assets Path": six.ensure_str(widget.unreal_turntable_asset_widget.text()),
+            "Unreal Project Path": widget.unreal_setup_widget.unreal_project_path,
+            "Turntable Map Path": widget.unreal_turntable_map_widget.text(),
+            "Sequence Path": widget.unreal_sequence_widget.text(),
+            "Turntable Assets Path": widget.unreal_turntable_asset_widget.text(),
             # "HDR Path": widget.hdr_image_template_widget.get_path(),
             # "Start Frame": widget.start_frame_spin_box.value(),
             # "End Frame": widget.end_frame_spin_box.value(),
@@ -1083,13 +1093,13 @@ class MayaUnrealTurntablePublishPlugin(HookBaseClass):
         # "environment can only contain strings" erors will happen.
         extra_env = {
             # The FBX to import into Unreal
-            "UNREAL_SG_FBX_OUTPUT_PATH": six.ensure_str(fbx_output_path),
+            "UNREAL_SG_FBX_OUTPUT_PATH": fbx_output_path,
             # The Unreal content browser folder where the asset will be imported into
-            "UNREAL_SG_ASSETS_PATH": six.ensure_str(turntable_assets_path),
+            "UNREAL_SG_ASSETS_PATH": turntable_assets_path,
             # The Unreal turntable map to duplicate where the asset will be instantiated into
-            "UNREAL_SG_MAP_PATH": six.ensure_str(turntable_map_path),
-            "UNREAL_SG_SEQUENCE_PATH": six.ensure_str(sequence_path),
-            "UNREAL_SG_MOVIE_OUTPUT_PATH": six.ensure_str(publish_path),
+            "UNREAL_SG_MAP_PATH": turntable_map_path,
+            "UNREAL_SG_SEQUENCE_PATH": sequence_path,
+            "UNREAL_SG_MOVIE_OUTPUT_PATH": publish_path,
         }
         self.logger.info("Adding %s to the environment" % extra_env)
         run_env.update(extra_env)


### PR DESCRIPTION
Fixed turntable hook for UE 5.4 and latest Maya.
- Removed all `six` related code.
- Fixed problems for PySide6.
- Added turntable project for UE 5.4.
- Fixed some problems in bootstrap hook example.