### PR TITLE
14333 secondary publishes fixes

### DIFF
--- a/hooks/tk-multi-publish2/tk-maya/basic/publish_fbx.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/publish_fbx.py
@@ -293,9 +293,27 @@ class MayaFBXPublishPlugin(HookBaseClass):
 
         return True
 
+    def _copy_to_publish(self, settings, item):
+        """
+        Override base implementation to do nothing
+        since we're not copying a file but exporting
+        directly to the publish location.
+        """
+        pass
+
+    def _copy_local_to_publish(self, settings, item):
+        """
+        Override base implementation to do nothing
+        since we're not copying a file but exporting
+        directly to the publish location.
+        """
+        pass
+
     def _copy_work_to_publish(self, settings, item):
         """
-        Override base implementation to do nothing.
+        Override base implementation to do nothing
+        since we're not copying a file but exporting
+        directly to the publish location.
         """
         pass
 

--- a/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
@@ -988,9 +988,13 @@ class MayaUnrealTurntablePublishPlugin(HookBaseClass):
         # The FBX will be exported to a temp folder
         # Another folder can be specified as long as the name has no spaces
         # Spaces are not allowed in command line Unreal Python args
+
+        # Set a base temp dir on Windows to avoid having
+        # the user name in the temp path which can include
+        # "." e.g. firstname.name and makes UE crashes
         base_temp_dir = None
         if sys.platform == "win32":
-            base_temp_dir = "C:\Temp"
+            base_temp_dir = r"C:\Temp"
         temp_folder = tempfile.mkdtemp(suffix="temp_unreal_shotgun", dir=base_temp_dir)
         # Store the temp folder path on the item for cleanup in finalize
         item.local_properties["temp_folder"] = temp_folder
@@ -1618,6 +1622,7 @@ class MayaUnrealTurntablePublishPlugin(HookBaseClass):
         """
         pass
 
+
 def _short_version(version):
     """
     Return a short major.minor version for the given version.
@@ -1629,7 +1634,7 @@ def _short_version(version):
     """
     parts = version.split(".", 2)
     if len(parts) > 2:
-         return ".".join(parts[:2])
+        return ".".join(parts[:2])
     return version
 
 

--- a/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
@@ -1591,9 +1591,27 @@ class MayaUnrealTurntablePublishPlugin(HookBaseClass):
             )
         )
 
+    def _copy_to_publish(self, settings, item):
+        """
+        Override base implementation to do nothing
+        since we're not copying a file but rendering
+        directly to the publish location.
+        """
+        pass
+
+    def _copy_local_to_publish(self, settings, item):
+        """
+        Override base implementation to do nothing
+        since we're not copying a file but rendering
+        directly to the publish location.
+        """
+        pass
+
     def _copy_work_to_publish(self, settings, item):
         """
-        Override base implementation to do nothing.
+        Override base implementation to do nothing
+        since we're not copying a file but rendering
+        directly to the publish location.
         """
         pass
 

--- a/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
+++ b/hooks/tk-multi-publish2/tk-maya/basic/publish_turntable.py
@@ -988,7 +988,10 @@ class MayaUnrealTurntablePublishPlugin(HookBaseClass):
         # The FBX will be exported to a temp folder
         # Another folder can be specified as long as the name has no spaces
         # Spaces are not allowed in command line Unreal Python args
-        temp_folder = tempfile.mkdtemp(suffix="temp_unreal_shotgun")
+        base_temp_dir = None
+        if sys.platform == "win32":
+            base_temp_dir = "C:\Temp"
+        temp_folder = tempfile.mkdtemp(suffix="temp_unreal_shotgun", dir=base_temp_dir)
         # Store the temp folder path on the item for cleanup in finalize
         item.local_properties["temp_folder"] = temp_folder
         fbx_folder = temp_folder
@@ -1043,7 +1046,7 @@ class MayaUnrealTurntablePublishPlugin(HookBaseClass):
         # Use the unreal_setup_turntable to do this in Unreal
         self.logger.info("Setting up Unreal turntable project...")
         # Copy the Unreal project in a temp location so we can modify it
-        temp_dir = tempfile.mkdtemp()
+        temp_dir = tempfile.mkdtemp(dir=base_temp_dir)
         project_path, project_file = os.path.split(unreal_project_path)
         project_folder = os.path.basename(project_path)
         temp_project_dir = os.path.join(temp_dir, project_folder)


### PR DESCRIPTION
Fixed secondary publishes being overwritten with the primary publish by overriding some new "copy" methods.
Fixed a problem with temporary paths on Windows which would cause UE crashes.
Fixed wrongly indented block